### PR TITLE
Ref/config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,17 @@ As you'll see underneath the control, there is also a port, username and passwor
 
 You can modify these values if needed, but if you do not care about authentication you can also leave the username and password fields blank. Only the port is required.
 
-If you've cloned the project, you'll find a config.yml file at the root. Otherwise, you'll need to create it alongside the executable.
-Fill in the values as you've configured in Feishin and feishin-controls will read these values at runtime to authenticate to the remote control server.
-
+You'll use these values to initialize feishin-controls' config file.
+You can run
+```bash
+./feishin-controls init
+```
+for an interactive prompt where you'll be asked to fill in the parameters.
+Or you can use
+```bash
+./feishin-controls init [url] [username] [password]
+```
+to directly pass the parameters and create the config file
 ## Usage
 You can then get a list of the different commands using
 ```bash

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/marc-antoinegelinas/feishin-controls/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}
+
+var initCmd = &cobra.Command{
+	Use:   "init [url] [username] [password]",
+	Short: "Initialize feishin-controls",
+	Long:  "Initializes feishin-controls config file",
+	Run: func(cmd *cobra.Command, args []string) {
+		var cfg config.ConfigFields
+		if len(args) == 3 {
+			cfg.Url = args[0]
+			cfg.Username = args[1]
+			cfg.Password = args[2]
+		} else if len(args) == 0 {
+			fmt.Print("To initialize feishin-controls, enable Feishin's remote control server in Settings->General\n")
+			fmt.Print("Enter the url. By default it should be localhost:4333, unless you're using a reverse proxy.\n")
+
+			_, err := fmt.Scanln(&cfg.Url)
+			if err != nil {
+				log.Fatal("failed to scan value:", err)
+			}
+
+			fmt.Print("Enter the username.\n")
+			_, err = fmt.Scanln(&cfg.Username)
+			if err != nil {
+				log.Fatal("failed to scan value:", err)
+			}
+
+			fmt.Print("Enter the password.\n")
+			_, err = fmt.Scanln(&cfg.Password)
+			if err != nil {
+				log.Fatal("failed to scan value:", err)
+			}
+		} else {
+			log.Fatal("init takes either 0 or 3 arguments ([url] [username] [password])")
+		}
+
+		config.CreateConfigFile(cfg)
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"fmt"
 	"log"
-	"os"
 	"path/filepath"
-	"runtime"
 
+	"github.com/marc-antoinegelinas/feishin-controls/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -26,67 +24,21 @@ func init() {
 	initConfig()
 }
 
-func getConfigDir() (string, error) {
-	var configDir string
-
-	switch runtime.GOOS {
-	case "windows":
-		configDir = os.Getenv("APPDATA")
-	case "darwin":
-		configDir = filepath.Join(os.Getenv("HOME"), "Library", "Application Support")
-	default:
-		configDir = filepath.Join(os.Getenv("HOME"), ".config")
-	}
-
-	if configDir == "" {
-		return "", fmt.Errorf("could not determine config directory for os")
-	}
-
-	return filepath.Join(configDir, "feishin-controls"), nil
-}
-
-func configFileExist(configFile string) bool {
-	_, err := os.Stat(configFile)
-	return err == nil
-}
-
-func createConfigFile(configPath string, configFile string) {
-	err := os.MkdirAll(configPath, 0755)
-	if err != nil {
-		log.Fatal("could not create config file with permissions:", err)
-	}
-
-	viper.Set("URL", "localhost:4333")
-	viper.Set("Username", "")
-	viper.Set("Password", "")
-
-	err = viper.SafeWriteConfigAs(configFile)
-	if err != nil {
-		log.Fatal("could not write config file:", err)
-	}
-}
-
 func initConfig() {
-	configPath, err := getConfigDir()
+	configFilePath, err := config.GetConfigFilePath()
 	if err != nil {
 		log.Fatal("could not get config dir:", err)
 	}
 
 	viper.SetConfigName("config")
 	viper.SetConfigType("yml")
-	viper.AddConfigPath(configPath)
-
-	configFile := filepath.Join(configPath, "config.yml")
-
-	if !configFileExist(configFile) {
-		createConfigFile(configPath, configFile)
-	}
+	viper.AddConfigPath(filepath.Dir(configFilePath))
 
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			fmt.Print("config.yml wasn't found in the running directory. Create and populate it.")
+			log.Fatal("config.yml wasn't found in the running directory. Create and populate it:\n", err)
 		} else {
-			fmt.Print("config.yml was found, but something else went wrong.")
+			log.Fatal("config.yml was found, but something else went wrong:\n", err)
 		}
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 
 	"github.com/marc-antoinegelinas/feishin-controls/internal/config"
@@ -13,6 +15,27 @@ var rootCmd = &cobra.Command{
 	Use:   "feishin-controls",
 	Short: "feishin-controls is a cli tool to control feishin",
 	Long:  "feishin-controls is a cli tool to control feishin via the websockets using the Remote Control",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		configFilePath, err := config.GetConfigFilePath()
+		if err != nil {
+			log.Fatal("could not get config dir:", err)
+		}
+
+		viper.SetConfigName("config")
+		viper.SetConfigType("yml")
+		viper.AddConfigPath(filepath.Dir(configFilePath))
+
+		if err := viper.ReadInConfig(); err != nil {
+			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+				if cmd.Name() != "init" {
+					fmt.Println("No config file found. Run the <init> command to generate it")
+					os.Exit(1)
+				}
+			} else {
+				log.Fatal("config.yml was found, but something else went wrong:\n", err)
+			}
+		}
+	},
 }
 
 func Execute() error {
@@ -21,24 +44,4 @@ func Execute() error {
 
 func init() {
 	cobra.OnInitialize()
-	initConfig()
-}
-
-func initConfig() {
-	configFilePath, err := config.GetConfigFilePath()
-	if err != nil {
-		log.Fatal("could not get config dir:", err)
-	}
-
-	viper.SetConfigName("config")
-	viper.SetConfigType("yml")
-	viper.AddConfigPath(filepath.Dir(configFilePath))
-
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			log.Fatal("config.yml wasn't found in the running directory. Create and populate it:\n", err)
-		} else {
-			log.Fatal("config.yml was found, but something else went wrong:\n", err)
-		}
-	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -22,13 +26,60 @@ func init() {
 	initConfig()
 }
 
+func getConfigDir() (string, error) {
+	var configDir string
+
+	switch runtime.GOOS {
+	case "windows":
+		configDir = os.Getenv("APPDATA")
+	case "darwin":
+		configDir = filepath.Join(os.Getenv("HOME"), "Library", "Application Support")
+	default:
+		configDir = filepath.Join(os.Getenv("HOME"), ".config")
+	}
+
+	if configDir == "" {
+		return "", fmt.Errorf("could not determine config directory for os")
+	}
+
+	return filepath.Join(configDir, "feishin-controls"), nil
+}
+
+func configFileExist(configFile string) bool {
+	_, err := os.Stat(configFile)
+	return err == nil
+}
+
+func createConfigFile(configPath string, configFile string) {
+	err := os.MkdirAll(configPath, 0755)
+	if err != nil {
+		log.Fatal("could not create config file with permissions:", err)
+	}
+
+	viper.Set("URL", "localhost:4333")
+	viper.Set("Username", "")
+	viper.Set("Password", "")
+
+	err = viper.SafeWriteConfigAs(configFile)
+	if err != nil {
+		log.Fatal("could not write config file:", err)
+	}
+}
+
 func initConfig() {
+	configPath, err := getConfigDir()
+	if err != nil {
+		log.Fatal("could not get config dir:", err)
+	}
+
 	viper.SetConfigName("config")
 	viper.SetConfigType("yml")
-	viper.AddConfigPath(".")
-	err := viper.ReadInConfig()
-	if err != nil {
-		panic(fmt.Errorf("fatal error reading config file: %w", err))
+	viper.AddConfigPath(configPath)
+
+	configFile := filepath.Join(configPath, "config.yml")
+
+	if !configFileExist(configFile) {
+		createConfigFile(configPath, configFile)
 	}
 
 	if err := viper.ReadInConfig(); err != nil {

--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,0 @@
-URL: "localhost:4333"
-Username: ""
-Password: ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/spf13/viper"
+)
+
+type ConfigFields struct {
+	Url      string
+	Username string
+	Password string
+}
+
+func GetConfigFilePath() (string, error) {
+	var configDir string
+
+	switch runtime.GOOS {
+	case "windows":
+		configDir = os.Getenv("APPDATA")
+	case "darwin":
+		configDir = filepath.Join(os.Getenv("HOME"), "Library", "Application Support")
+	default:
+		configDir = filepath.Join(os.Getenv("HOME"), ".config")
+	}
+
+	if configDir == "" {
+		return "", fmt.Errorf("could not determine config directory for os")
+	}
+
+	return filepath.Join(configDir, "feishin-controls", "config.yml"), nil
+}
+
+func CreateConfigFile(configs ConfigFields) {
+	configFile, err := GetConfigFilePath()
+	if err != nil {
+		log.Fatal("could not get config file", err)
+	}
+
+	err = os.MkdirAll(filepath.Dir(configFile), 0755)
+	if err != nil {
+		log.Fatal("could not create config file with permissions:", err)
+	}
+
+	viper.Set("URL", configs.Url)
+	viper.Set("Username", configs.Username)
+	viper.Set("Password", configs.Password)
+
+	err = viper.WriteConfigAs(configFile)
+	if err != nil {
+		log.Fatal("could not write config file:", err)
+	}
+
+	fmt.Printf("Config file created: %s\n", configFile)
+}


### PR DESCRIPTION
Viper was configured to look into the "." directory to search for the config file. This made it so that trying to call feishin-controls from anywhere else other than the executable directory would not work as the config file would not be in the cwd.

Refactored so that the config file is created in the appropriate OS config directory and read from there accordingly.

Also added the <init> command to create the config file as well as giving an error message explaining to do so when the file does not exist.